### PR TITLE
Incorrect versioning in README

### DIFF
--- a/.github/workflows/test-absolute.yml
+++ b/.github/workflows/test-absolute.yml
@@ -1,0 +1,36 @@
+name: "build-test-absolute"
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set Node.js 12
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12.x
+    - run: npm ci
+    - run: npm run build
+      
+  test:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup ReSharper CTL
+        uses: goit/setup-resharper@v2.0.0
+        with:
+          version: 2021.2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Basic:
 ```yaml
 steps:
 - uses: actions/checkout@master
-- uses: goit/setup-resharper@v2
+- uses: goit/setup-resharper@v2.0.0
   with:
     version: '2021.2'
 - run: InspectCode <solution file>
@@ -24,9 +24,9 @@ steps:
 
 ## Note
 
-Use `goit/setup-resharper@v1` for ReSharper CTL 2020.1 and older releases.
+Use `goit/setup-resharper@v1.0.0` for ReSharper CTL 2020.1 and older releases.
 
-The download address changed and `goit/setup-resharper@v2` supports ReSharper CTL 2020.2 and newer.
+The download address changed and `goit/setup-resharper@v2.0.0` supports ReSharper CTL 2020.2 and newer.
 
 ## License
 


### PR DESCRIPTION
I noticed that on some runners (e.g. `ubuntu-latest`) the package cannot be resolved via the version suggested in the README (`goit/setup-resharper@v2`). The problem is with the tag: there is no such tag as `v2`, only `v2.0.0` and higher. 

I created a test that tries to setup the package by an absolute reference rather then from local files. [Here](https://github.com/Delt06/setup-resharper/actions/runs/1220330874) is how it behaves with `v2`. And [here](https://github.com/Delt06/setup-resharper/actions/runs/1220345075) with `v2.0.0`. I also made a change to the README to ensure it provides the correct way to reference your package.
